### PR TITLE
Correct sshd_config for redhat/osx distributions

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -86,4 +86,5 @@ when 'rhel', 'fedora'
 when 'mac_os_x'
   default['sshd']['sshd_config']['SyslogFacility'] = 'AUTHPRIV'
   default['sshd']['sshd_config']['UsePrivilegeSeparation'] = 'sandbox'
+  default['sshd']['sshd_config']['X11Forwarding'] = 'no'
 end


### PR DESCRIPTION
This Env variable is in all Redhat distributions.
