### PR TITLE
Fix service commands on Ubuntu 14.04

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -27,6 +27,7 @@ directory File.dirname(node['sshd']['config_file']) do
 end
 
 service node['sshd']['service_name'] do
+  provider Chef::Provider::Service::Upstart if node.platform == 'ubuntu'
   supports status: true, restart: true, reload: true
   action [ :enable, :start ]
 end


### PR DESCRIPTION
The recipe `sshd::default` doesn't converge cleanly on Ubuntu 14.04, it errors when trying to start the sshd service - research on the topic suggests 13.10 may have the same issue. This change allows a clean convergence, and has been tested on ubuntu 12.04 as well.
