### PR TITLE
Remove chef-client < 11.14 workaround in install.rb (already removed from definitions/openssh_server.rb)

### DIFF
--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -27,9 +27,6 @@ directory File.dirname(node['sshd']['config_file']) do
 end
 
 service node['sshd']['service_name'] do
-  # Due to a bug in Chef, we need to manually set the provider to Upstart for Ubuntu 13.10 and 14.04
-  # This will probably be fixed in chef-client 11.14
-  provider Chef::Provider::Service::Upstart if node['platform'] == 'ubuntu' && node['platform_version'] >= '13.10'
   supports status: true, restart: true, reload: true
   action [:enable, :start]
 end


### PR DESCRIPTION
Same fix as https://github.com/chr4-cookbooks/sshd/commit/634f44125b7cc1d8fa146011a7d476f7d0728d47
