### PR TITLE
Use full path to 'sshd' when testing config - fixes #11

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,7 @@ platforms:
 - name: ubuntu-12.04
 - name: debian-7.2.0
 - name: debian-6.0.8
+- name: centos-7.2
 - name: centos-6.5
 - name: centos-5.10
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ node['sshd']['package']      # package to install openssh-server
 The following settings will be filled in using the defaults of the distribution you're using, unless you overwrite it in your node configuration / definition
 
 ```ruby
+node['sshd']['sshd_path']    # path to sshd executable
 node['sshd']['config_file']  # path to sshd_config
 node['sshd']['service_name'] # sshd service name
 ```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,6 +26,14 @@ else
   'openssh-server'
 end
 
+# Path to 'sshd' executable
+default['sshd']['sshd_path'] = case node['platform']
+when 'redhat', 'centos'
+  node['platform_version'].to_i >= 7 ? '/sbin/sshd' : '/usr/sbin/sshd'
+else
+  '/usr/sbin/sshd'
+end
+
 # Path to 'sshd_config' configuration file
 default['sshd']['config_file'] = case node['platform_family']
 when 'mac_os_x'

--- a/definitions/openssh_server.rb
+++ b/definitions/openssh_server.rb
@@ -36,7 +36,7 @@ define :openssh_server, action: :create, cookbook: 'sshd', source: 'sshd_config.
 
   # Check sshd_config
   execute 'check_sshd_config' do
-    command "sshd -t -f #{filename}"
+    command "#{node['sshd']['sshd_path']} -t -f #{filename}"
     action :nothing
   end
 


### PR DESCRIPTION
This PR fixes #11 by setting an attribute named `['sshd']['sshd_path']` which contains the absolute path to the `sshd` executable. `sshd` is in `/usr/sbin` on RHEL/CentOS 7, so the default value is different on those platform/version combinations.