### PR TITLE
Make rubocop passable

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,10 @@
+Metrics/BlockLength:
+  Exclude:
+    - 'Rakefile'
+    - '**/*.rake'
+    - 'test/**/*.rb'
+    - spec/**/*
+
 LineLength:
   Max: 200
 
@@ -5,7 +12,7 @@ HashSyntax:
   EnforcedStyle: ruby19
 
 CaseIndentation:
-  IndentWhenRelativeTo: end
+  EnforcedStyle: end
 
 MethodLength:
   Max: 50

--- a/Gemfile
+++ b/Gemfile
@@ -17,5 +17,5 @@ group :kitchen_vagrant do
   gem 'kitchen-vagrant', '~> 0.11'
 end
 
-gem 'rspec'
 gem 'chefspec'
+gem 'rspec'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -59,10 +59,10 @@ default['sshd']['sshd_config'] = {
   'Port' => 22,
   'Protocol' => 2,
   'AcceptEnv' => 'LANG LC_*',
-  'HostKey' => %w(/etc/ssh/ssh_host_rsa_key
+  'HostKey' => %w[/etc/ssh/ssh_host_rsa_key
                   /etc/ssh/ssh_host_ed25519_key
                   /etc/ssh/ssh_host_dsa_key
-                  /etc/ssh/ssh_host_ecdsa_key),
+                  /etc/ssh/ssh_host_ecdsa_key],
   'PasswordAuthentication' => 'yes',
   'ChallengeResponseAuthentication' => 'no',
   'X11Forwarding' => 'yes',

--- a/files/default/tests/minitest/default_test.rb
+++ b/files/default/tests/minitest/default_test.rb
@@ -18,7 +18,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-require File.expand_path('../support/helpers', __FILE__)
+require File.expand_path('support/helpers', __dir__)
 
 describe 'sshd::default' do
   include Helpers::TestHelper
@@ -29,9 +29,7 @@ describe 'sshd::default' do
 
   it 'should create sshd_config according to specifications' do
     file(node['sshd']['config_file']).must_include('Port 1234')
-    if node['sshd']['sshd_config']['ListenAddress']
-      file(node['sshd']['config_file']).must_match(/Port.+ListenAddress/m)
-    end
+    file(node['sshd']['config_file']).must_match(/Port.+ListenAddress/m) if node['sshd']['sshd_config']['ListenAddress']
   end
 
   it 'should start openssh-server service' do

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -59,7 +59,7 @@ module Sshd
       sshd_config << conditional_blocks
     end
 
-    # Merge d (defaults) with new hash (n)
+    # Merge default values with the new hash
     def merge_settings(defaults, new_hash)
       r = defaults.to_hash
       new_hash.each { |k, v| r[k.to_s] = v }

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -60,9 +60,9 @@ module Sshd
     end
 
     # Merge d (defaults) with new hash (n)
-    def merge_settings(d, n)
-      r = d.to_hash
-      n.each { |k, v| r[k.to_s] = v }
+    def merge_settings(defaults, new_hash)
+      r = defaults.to_hash
+      new_hash.each { |k, v| r[k.to_s] = v }
       r
     end
   end


### PR DESCRIPTION
First error fails due to an obsolete parameter:

```
Error: obsolete parameter IndentWhenRelativeTo (for Layout/CaseIndentation) found in .rubocop.yml
`IndentWhenRelativeTo` has been renamed to `EnforcedStyle
````

From there, various changes to offending scripts to make `rubocop` pass.