### PR TITLE
Migrate definitions to a custom resource

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,4 +29,9 @@ directory File.dirname(node['sshd']['config_file']) do
 end
 
 # Configure service
-openssh_server node['sshd']['config_file']
+openssh_server node['sshd']['config_file'] do
+  name            node['sshd']['config_file']
+  cookbook        'sshd'
+  source          'sshd_config.erb'
+  action          :create
+end


### PR DESCRIPTION
Since definitions are no longer recommended, migrating them to a custom resource seemed like a decent thing to do.  While the tests will pass, it throws an deprecation error which is related to `minitest`.  This error exists even with `definitions`.

```
         - MiniTest::Chef::Handler
       Running handlers complete

       Deprecated features used!
         Resource chef_handler from a cookbook is overriding the resource from the client. Please upgrade your cookbook or remove the cookbook from your run_list before the next major release of Chef. at 1 location:
           - /opt/chef/embedded/lib/ruby/gems/2.5.0/gems/chef-14.5.33/lib/chef/log.rb:51:in `caller_location'
          See https://docs.chef.io/deprecations_map_collision.html for further details.
```