### PR TITLE
Add Arch and Amazon Linux SFTP subsystem support.

### DIFF
--- a/.github/workflows/chef.yml
+++ b/.github/workflows/chef.yml
@@ -18,11 +18,11 @@ jobs:
     - name: Check out code
       uses: actions/checkout@master
     - name: Install Chef
-      uses: actionshub/chef-install@master
+      uses: actionshub/chef-install@main
     - name: Linting
       run: cookstyle -f simple || (echo "Run 'cookstyle -a' to correct cookstyle errors." && exit 1)
     - name: test-kitchen
-      uses: actionshub/test-kitchen@master
+      uses: actionshub/test-kitchen@main
       with:
         suite: ${{ matrix.suite }}
         os: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ sshd CHANGELOG
 
 This file is used to list changes made in each version of the sshd cookbook.
 
+3.1.0
+
+- Add Arch and Amazon linux platforms. Replace foodcritic in Gemfile in favor of cookstyle - [@jhboricua](https://github.com/jhboricua)
+
 3.0.0
 -----
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
 group :lint do
-  gem 'foodcritic'
-  gem 'rubocop'
+  gem 'cookstyle'
 end
 
 group :unit do

--- a/README.md
+++ b/README.md
@@ -189,4 +189,4 @@ Contributions of any sort are very welcome!
 # License and Authors
 
 Authors: Chris Aumann <me@chr4.org>
-Contributors: Jeremy Olliver, Andy Thompson, Peter Walz, Kevin Olbrich, Johnny Martin, Renato Covarrubias
+Contributors: Jeremy Olliver, Andy Thompson, Peter Walz, Kevin Olbrich, Johnny Martin, Renato Covarrubias, Jose A. Hernandez

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -72,22 +72,32 @@ default['sshd']['sshd_config_mode'] =
   case node['platform_family']
   when 'debian', 'mac_os_x'
     '0o644'
-  when 'rhel', 'fedora'
+  when 'amazon', 'arch', 'fedora', 'rhel'
     '0o600'
   end
 
 # Initialize sftp subsystem
 default['sshd']['sshd_config']['Subsystem'] =
   case node['platform_family']
+  when 'arch'
+    'sftp /usr/lib/ssh/sftp-server'
   when 'debian'
     'sftp /usr/lib/openssh/sftp-server'
-  when 'rhel', 'fedora'
+  when 'amazon', 'fedora', 'rhel'
     'sftp /usr/libexec/openssh/sftp-server'
   when 'mac_os_x'
     'sftp /usr/libexec/sftp-server'
   end
 
 case node['platform_family']
+when 'amazon'
+  default['sshd']['sshd_config']['SyslogFacility'] = 'AUTHPRIV'
+  default['sshd']['sshd_config']['AcceptEnv'] = 'LANG LANGUAGE LC_* XMODIFIERS'
+
+when 'arch'
+  default['sshd']['sshd_config']['SyslogFacility'] = 'AUTH'
+  default['sshd']['sshd_config']['X11Forwarding'] = 'no'
+
 when 'debian'
   # On debian-like systems, pam takes care of the motd
   default['sshd']['sshd_config']['PrintMotd'] = 'no'

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,12 +3,12 @@ maintainer       'Chris Aumann'
 maintainer_email 'me@chr4.org'
 license          'GPL-3.0-or-later'
 description      'Installs/Configures sshd'
-version          '3.0.0'
+version          '3.1.0'
 source_url       'https://github.com/chr4-cookbooks/sshd'
 issues_url       'https://github.com/chr4-cookbooks/sshd/issues'
 
-%w(ubuntu debian redhat centos).each do |os|
+%w(amazon centos debian fedora redhat ubuntu).each do |os|
   supports os
 end
 
-chef_version '>= 12.7'
+chef_version '>= 15.0'

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -55,7 +55,7 @@ action :create do
     group 'root'
     mode '0755'
     action :create
-    only_if { platform?('debian') || platform?('ubuntu') }
+    only_if { platform?('debian', 'ubuntu') }
   end
 
   template filename do


### PR DESCRIPTION
Added support for enabling the SFTP subsystem on Amazon Linux and (per #9) Arch Linux. 

Signed-off-by: Jose Hernandez <jhboricua@gmail.com>